### PR TITLE
Added FastAPI and `/cities` endpoint to server

### DIFF
--- a/server/dev-requirements.txt
+++ b/server/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest>=8.3.4
 pytest-cov>=6.0.0
+httpx>=0.28.1

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,3 +5,5 @@ requests>=2.32.3
 networkx>=3.4.2
 pyproj>=3.7.1
 shapely>=2.0.7
+fastapi>=0.115.12
+uvicorn>=0.34.0

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -1,0 +1,39 @@
+import logging
+import os
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+from src.model import CityConfiguration
+
+CONFIG_DIRECTORY_PATH = Path(__file__).parents[1] / "config" / "cities"
+
+
+app = FastAPI()
+logger = logging.getLogger(__name__)
+
+
+@app.get("/cities")
+def cities():
+    city_configurations: list[CityConfiguration] = []
+
+    for file in filter(lambda x: x.is_file(), CONFIG_DIRECTORY_PATH.iterdir()):
+        try:
+            city_configurations.append(
+                CityConfiguration.model_validate_json(file.read_text())
+            )
+        except ValidationError as exc:
+            logger.exception(f"Invalid configuration file: {file.name}", exc_info=exc)
+            return JSONResponse("Invalid configuration files", 500)
+
+    return city_configurations
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host=os.environ.get("APP_HOST", "127.0.0.1"),
+        port=os.environ.get("APP_PORT", 8000),
+    )

--- a/server/tests/test_server.py
+++ b/server/tests/test_server.py
@@ -1,0 +1,61 @@
+import logging
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from src.server import app
+
+
+class TestServer:
+    client = TestClient(app)
+
+    def test_cities(self):
+        response = self.client.get("/cities")
+        cities = response.json()
+
+        assert response.status_code == 200
+        assert isinstance(cities, list)
+
+        for city in cities:
+            osm_area_name = city["osm_area_name"]
+            assert osm_area_name
+            assert isinstance(osm_area_name, str)
+
+            gtfs_url = city["gtfs_url"]
+            assert gtfs_url
+            assert isinstance(gtfs_url, str)
+
+            url_parse_result = urllib.parse.urlparse(gtfs_url)
+            assert url_parse_result.scheme
+            assert url_parse_result.netloc
+
+            ignored_gtfs_lines = city["ignored_gtfs_lines"]
+            assert isinstance(ignored_gtfs_lines, list)
+            assert all(isinstance(line, str) for line in ignored_gtfs_lines)
+            assert len(set(ignored_gtfs_lines)) == len(ignored_gtfs_lines)
+
+            custom_stop_mapping = city["custom_stop_mapping"]
+            assert isinstance(custom_stop_mapping, dict)
+            assert all(
+                isinstance(gtfs_stop_id, str) for gtfs_stop_id in custom_stop_mapping
+            )
+            assert all(
+                isinstance(osm_node_id, int)
+                for osm_node_id in custom_stop_mapping.values()
+            )
+
+        assert any(city["osm_area_name"] == "Kraków" for city in cities)
+
+    @patch("pathlib.Path.read_text", return_value="{Malformed json")
+    def test_cities_validation_error(
+        self, read_text_mock: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.ERROR, logger="src.server"):
+            response = self.client.get("/cities")
+
+        assert response.status_code == 500
+        assert response.json() == "Invalid configuration files"
+
+        assert "Invalid configuration file: " in caplog.text
+        assert "ValidationError" in caplog.text


### PR DESCRIPTION
### Related issues
- https://github.com/RCRalph/TNSEngineerEdition/issues/21

### Short description
Added FastAPI to dependencies and `httpx` to dev dependencies, required for tests in `TestClient` class.
Added boilerplate setup for FastAPI with `/cities` endpoint.
Created test cases for `/cities` endpoint.
