### PR TITLE
added atributes to edges and nodes

### DIFF
--- a/server/src/tram_track_graph_transformer/node.py
+++ b/server/src/tram_track_graph_transformer/node.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 from src.tram_track_graph_transformer.node_type import NodeType
 
@@ -10,12 +12,14 @@ class Node(BaseModel, frozen=True):
         lat (float): Geographic latitude of the node.
         lon (float): Geographic longitude of the node.
         type (NodeType): Type of the node (e.g., tram stop, switch).
+        name (Optional[str]): The name of the tram stop, set only when type == NodeType.TRAM_STOP.
     """
 
     id: int
     lat: float
     lon: float
     type: NodeType
+    name: Optional[str] = None
 
     @property
     def coordinates(self):


### PR DESCRIPTION
### Related issues
- #19

### Short description
Add `name` attribute to nodes if available; otherwise set to `None`. Azimuth and length of edges in the densified graph are now computed during their creation. No tests yet — pending initial feedback.